### PR TITLE
サインアップ/ログイン時のエラー処理

### DIFF
--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -21,7 +21,7 @@
             <nuxt-link to="/auth/signup" class="button is-primary">
               <strong>Sign up</strong>
             </nuxt-link>
-            <nuxt-link to="/auth/signin" class="button is-light">
+            <nuxt-link to="/auth/login" class="button is-light">
               Log in
             </nuxt-link>
           </div>

--- a/src/middleware/authenticated.js
+++ b/src/middleware/authenticated.js
@@ -1,5 +1,5 @@
 export default function({ store, redirect }) {
   if (!store.getters.isAuthenticated) {
-    return redirect('/auth/signin')
+    return redirect('/auth/login')
   }
 }

--- a/src/pages/auth/login.vue
+++ b/src/pages/auth/login.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="container">
-    <h1>これはサインイン用のページ</h1>
+    <h1>これはログイン用のページ</h1>
     <p>
       もしまだアカウントを作成していなかったら
       <nuxt-link to="/auth/signup">サインアップのページ</nuxt-link>
@@ -16,7 +16,7 @@
       </b-field>
     </div>
     <div>
-      <b-button @click="signIn">signIn</b-button>
+      <b-button @click="logIn">logIn</b-button>
     </div>
   </div>
 </template>
@@ -31,7 +31,7 @@ export default {
     }
   },
   methods: {
-    async signIn() {
+    async logIn() {
       try {
         if (this.email === '' || this.password === '') {
           alert('フォームが空です')

--- a/src/pages/auth/login.vue
+++ b/src/pages/auth/login.vue
@@ -65,8 +65,22 @@ export default {
           })
           this.$router.push('/')
         }
-      } catch (error) {
-        console.log(error)
+      } catch (e) {
+        console.log(e)
+        switch (e.code) {
+          case 'auth/user-not-found':
+            alert('ユーザが登録されていません')
+            break
+          case 'auth/wrong-password':
+            alert('パスワードが間違っています')
+            break
+          case 'auth/too-many-requests':
+            alert('しばらく時間を置いてください')
+            break
+          default:
+            alert('エラーが発生したようです')
+            break
+        }
       }
     }
   }

--- a/src/pages/auth/signin.vue
+++ b/src/pages/auth/signin.vue
@@ -33,6 +33,10 @@ export default {
   methods: {
     async signIn() {
       try {
+        if (this.email === '' || this.password === '') {
+          alert('フォームが空です')
+          return
+        }
         const res = await auth.signInWithEmailAndPassword(
           this.email,
           this.password

--- a/src/pages/auth/signup.vue
+++ b/src/pages/auth/signup.vue
@@ -19,6 +19,7 @@
           password-reveal
         ></b-input>
       </b-field>
+      <span>パスワードは6文字以上で設定してください</span>
     </div>
     <div>
       <b-button @click="signUp">signUp</b-button>
@@ -69,7 +70,15 @@ export default {
             this.$router.push('/')
           })
       } catch (e) {
-        console.error(e)
+        console.log(e)
+        switch (e.code) {
+          case 'auth/invalid-email':
+            alert('メールアドレスの形式が正しくありません')
+            break
+          case 'auth/weak-password':
+            alert('パスワードは6文字以上で設定してください')
+            break
+        }
       }
     }
   }

--- a/src/pages/auth/signup.vue
+++ b/src/pages/auth/signup.vue
@@ -78,6 +78,9 @@ export default {
           case 'auth/weak-password':
             alert('パスワードは6文字以上で設定してください')
             break
+          default:
+            alert('エラーが発生したようです')
+            break
         }
       }
     }

--- a/src/pages/auth/signup.vue
+++ b/src/pages/auth/signup.vue
@@ -3,7 +3,7 @@
     <h1>これはサインアップ用のページ</h1>
     <p>
       もしすでにアカウントを作成していたら
-      <nuxt-link to="/auth/signin">サインインのページ</nuxt-link
+      <nuxt-link to="/auth/login">ログインのページ</nuxt-link
       >でサインインしてください
     </p>
     <div>

--- a/src/pages/auth/signup.vue
+++ b/src/pages/auth/signup.vue
@@ -3,8 +3,8 @@
     <h1>これはサインアップ用のページ</h1>
     <p>
       もしすでにアカウントを作成していたら
-      <nuxt-link to="/auth/signin">サインインのページ</nuxt-link>
-      でサインインしてください
+      <nuxt-link to="/auth/signin">サインインのページ</nuxt-link
+      >でサインインしてください
     </p>
     <div>
       <b-field label="Email">
@@ -38,6 +38,10 @@ export default {
   methods: {
     async signUp() {
       try {
+        if (this.email === '' || this.password === '') {
+          alert('フォームが空です')
+          return
+        }
         // メアドがすでに使われているかの確認
         const providers = await auth.fetchSignInMethodsForEmail(this.email)
         if (providers.findIndex((p) => p === authProviderEmail) !== -1) {


### PR DESCRIPTION
Closes #25 

- [x] 今までコンソールに表示するだけだったのを適当にalertを出すようにした
- [x] サインインをログインに変えた
後々alertをbuefyのtoastとかに置き換えると見栄えが良くなると思います