### PR TITLE
ログイン系ページのスタイル

### DIFF
--- a/src/layouts/auth.vue
+++ b/src/layouts/auth.vue
@@ -5,7 +5,6 @@
         Slide-Share-Spot
       </section>
     </nuxt-link>
-
     <nuxt />
   </section>
 </template>
@@ -20,6 +19,7 @@ export default {}
   width: 450px;
   .title {
     text-align: center;
+    margin-bottom: 2rem;
   }
 }
 </style>

--- a/src/layouts/auth.vue
+++ b/src/layouts/auth.vue
@@ -1,8 +1,11 @@
 <template>
   <section class="section card">
-    <section class="is-size-2 has-text-weight-bold has-text-primary title">
-      Slide-Share-Spot
-    </section>
+    <nuxt-link to="/">
+      <section class="is-size-2 has-text-weight-bold has-text-primary title">
+        Slide-Share-Spot
+      </section>
+    </nuxt-link>
+
     <nuxt />
   </section>
 </template>

--- a/src/layouts/auth.vue
+++ b/src/layouts/auth.vue
@@ -1,51 +1,22 @@
 <template>
-  <section class="main-content columns">
-    <div class="container column is-10">
-      <nuxt />
-    </div>
+  <section class="section card">
+    <section class="is-size-2 has-text-weight-bold has-text-primary title">
+      Slide-Share-Spot
+    </section>
+    <nuxt />
   </section>
 </template>
 
 <script>
-export default {
-  data() {
-    return {
-      items: [
-        {
-          title: 'Home',
-          icon: 'home',
-          to: { name: 'index' }
-        },
-        {
-          title: 'Inspire',
-          icon: 'lightbulb',
-          to: { name: 'inspire' }
-        },
-        {
-          title: 'search',
-          icon: 'home',
-          to: { name: 'article-search' }
-        }
-      ]
-    }
-  },
-  computed: {
-    username() {
-      return this.$store.getters.username
-    },
-    isLogin() {
-      return this.$store.getters.isAuthenticated
-    }
-  },
-  methods: {
-    async logout() {
-      await this.$store.dispatch('logout')
-      this.$buefy.toast.open({
-        message: 'ログoutできました',
-        type: 'is-success'
-      })
-      this.$router.push('/')
-    }
+export default {}
+</script>
+
+<style lang="scss" scoped>
+.section {
+  margin: 200px auto auto;
+  width: 450px;
+  .title {
+    text-align: center;
   }
 }
-</script>
+</style>

--- a/src/layouts/auth.vue
+++ b/src/layouts/auth.vue
@@ -1,0 +1,51 @@
+<template>
+  <section class="main-content columns">
+    <div class="container column is-10">
+      <nuxt />
+    </div>
+  </section>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      items: [
+        {
+          title: 'Home',
+          icon: 'home',
+          to: { name: 'index' }
+        },
+        {
+          title: 'Inspire',
+          icon: 'lightbulb',
+          to: { name: 'inspire' }
+        },
+        {
+          title: 'search',
+          icon: 'home',
+          to: { name: 'article-search' }
+        }
+      ]
+    }
+  },
+  computed: {
+    username() {
+      return this.$store.getters.username
+    },
+    isLogin() {
+      return this.$store.getters.isAuthenticated
+    }
+  },
+  methods: {
+    async logout() {
+      await this.$store.dispatch('logout')
+      this.$buefy.toast.open({
+        message: 'ログoutできました',
+        type: 'is-success'
+      })
+      this.$router.push('/')
+    }
+  }
+}
+</script>

--- a/src/pages/auth/login.vue
+++ b/src/pages/auth/login.vue
@@ -11,7 +11,7 @@
 
     <div class="buttons">
       <nuxt-link to="/auth/signup" class="has-text-primary">
-        アカウントを作成
+        Create account
       </nuxt-link>
       <button class="button is-primary" @click="logIn">LogIn</button>
     </div>

--- a/src/pages/auth/login.vue
+++ b/src/pages/auth/login.vue
@@ -24,6 +24,7 @@
 <script>
 import { auth } from '~/plugins/firebaseSettings'
 export default {
+  layout: 'auth',
   data() {
     return {
       email: '',

--- a/src/pages/auth/login.vue
+++ b/src/pages/auth/login.vue
@@ -56,7 +56,7 @@ export default {
         })
 
         if (res.user.displayName == null)
-          this.$router.push('/register-username')
+          this.$router.push('/auth/set-username')
         else {
           this.$store.dispatch('login', {
             displayName: res.user.displayName

--- a/src/pages/auth/login.vue
+++ b/src/pages/auth/login.vue
@@ -1,22 +1,19 @@
 <template>
   <div class="container">
-    <h1>これはログイン用のページ</h1>
-    <p>
-      もしまだアカウントを作成していなかったら
-      <nuxt-link to="/auth/signup">サインアップのページ</nuxt-link>
-      でアカウントを作成してください。
-    </p>
-    <div>
+    <div class="input-area">
       <b-field label="Email">
         <b-input v-model="email" type="email" value="john@"></b-input>
       </b-field>
-
       <b-field label="Password">
         <b-input v-model="password" type="password" password-reveal></b-input>
       </b-field>
     </div>
-    <div>
-      <b-button @click="logIn">logIn</b-button>
+
+    <div class="buttons">
+      <nuxt-link to="/auth/signup" class="has-text-primary">
+        アカウントを作成
+      </nuxt-link>
+      <button class="button is-primary" @click="logIn">LogIn</button>
     </div>
   </div>
 </template>
@@ -87,3 +84,13 @@ export default {
   }
 }
 </script>
+
+<style lang="scss" scoped>
+.buttons {
+  margin: 2rem 0 0;
+  .button {
+    display: block;
+    margin: 0 0 0 auto;
+  }
+}
+</style>

--- a/src/pages/auth/set-username.vue
+++ b/src/pages/auth/set-username.vue
@@ -1,13 +1,16 @@
 <template>
   <div class="container">
-    <h1>これはユーザーネーム設定用のページ</h1>
+    <p>最初にユーザ名を登録してください</p>
     <div>
       <b-field label="Name">
         <b-input v-model="displayName"></b-input>
       </b-field>
     </div>
-    <div>
-      <b-button @click="registerUsername">usernameの登録</b-button>
+
+    <div class="button-area">
+      <button class="button is-primary" @click="setUsername">
+        usernameの登録
+      </button>
     </div>
   </div>
 </template>
@@ -15,13 +18,14 @@
 <script>
 import { auth } from '~/plugins/firebaseSettings'
 export default {
+  layout: 'auth',
   data() {
     return {
       displayName: ''
     }
   },
   methods: {
-    async registerUsername() {
+    async setUsername() {
       try {
         const user = await auth.currentUser
         if (user) {
@@ -39,3 +43,13 @@ export default {
   }
 }
 </script>
+
+<style lang="scss" scoped>
+.button-area {
+  margin: 2rem 0 0;
+  .button {
+    display: block;
+    margin: 0 0 0 auto;
+  }
+}
+</style>

--- a/src/pages/auth/signup.vue
+++ b/src/pages/auth/signup.vue
@@ -30,6 +30,7 @@
 <script>
 import { auth, authProviderEmail } from '~/plugins/firebaseSettings'
 export default {
+  layout: 'auth',
   data() {
     return {
       email: '',

--- a/src/pages/auth/signup.vue
+++ b/src/pages/auth/signup.vue
@@ -1,11 +1,5 @@
 <template>
   <div class="container">
-    <h1>これはサインアップ用のページ</h1>
-    <p>
-      もしすでにアカウントを作成していたら
-      <nuxt-link to="/auth/login">ログインのページ</nuxt-link
-      >でサインインしてください
-    </p>
     <div>
       <b-field label="Email">
         <b-input v-model="email" type="email" value="john@"></b-input>
@@ -21,8 +15,12 @@
       </b-field>
       <span>パスワードは6文字以上で設定してください</span>
     </div>
-    <div>
-      <b-button @click="signUp">signUp</b-button>
+
+    <div class="buttons">
+      <nuxt-link to="/auth/login" class="has-text-primary">
+        Login instead
+      </nuxt-link>
+      <button class="button is-primary" @click="signUp">signUp</button>
     </div>
   </div>
 </template>
@@ -88,3 +86,13 @@ export default {
   }
 }
 </script>
+
+<style lang="scss" scoped>
+.buttons {
+  margin: 2rem 0 0;
+  .button {
+    display: block;
+    margin: 0 0 0 auto;
+  }
+}
+</style>

--- a/src/pages/auth/signup.vue
+++ b/src/pages/auth/signup.vue
@@ -58,7 +58,7 @@ export default {
         // 確認メールの送信
         res.user
           .sendEmailVerification({
-            url: 'https://slide-share-spot.herokuapp.com/register-username.vue',
+            url: 'https://slide-share-spot.herokuapp.com/set-username.vue',
             handleCodeInApp: false
           })
           .then(() => {

--- a/src/pages/auth/signup.vue
+++ b/src/pages/auth/signup.vue
@@ -58,7 +58,7 @@ export default {
         // 確認メールの送信
         res.user
           .sendEmailVerification({
-            url: 'https://slide-share-spot.herokuapp.com/set-username.vue',
+            url: 'https://slide-share-spot.herokuapp.com/',
             handleCodeInApp: false
           })
           .then(() => {


### PR DESCRIPTION
close #44 

## やったこと
- auth 関連用のヘッダーなしlayoutの追加
- サインアップ、ログイン、ユーザ名登録ページのcss書いた
- メール認証後に飛ぶページを`/`にした


![スクリーンショット 2020-06-29 1 21 20](https://user-images.githubusercontent.com/39793156/85953010-36028300-b9a8-11ea-8009-41749f389735.png)
